### PR TITLE
Improve mask cleanup

### DIFF
--- a/bestweb_body_segmentation (3).html
+++ b/bestweb_body_segmentation (3).html
@@ -724,9 +724,52 @@
 
       // Remove small blobs from the mask using connected-component analysis
       function cleanMask(mask, width, height) {
+        function dilate(src) {
+          const out = new Uint8Array(src.length);
+          for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+              const idx = y * width + x;
+              if (src[idx]) {
+                for (let dy = -1; dy <= 1; dy++) {
+                  for (let dx = -1; dx <= 1; dx++) {
+                    const nx = x + dx, ny = y + dy;
+                    if (nx >= 0 && nx < width && ny >= 0 && ny < height) {
+                      out[ny * width + nx] = 1;
+                    }
+                  }
+                }
+              }
+            }
+          }
+          return out;
+        }
+
+        function erode(src) {
+          const out = new Uint8Array(src.length);
+          for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+              let keep = true;
+              for (let dy = -1; dy <= 1 && keep; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                  const nx = x + dx, ny = y + dy;
+                  if (nx < 0 || nx >= width || ny < 0 || ny >= height || !src[ny * width + nx]) {
+                    keep = false;
+                    break;
+                  }
+                }
+              }
+              out[y * width + x] = keep ? 1 : 0;
+            }
+          }
+          return out;
+        }
+
+        // Morphological closing to better preserve the person outline
+        mask = erode(dilate(mask));
+
         const visited = new Uint8Array(mask.length);
-        const MIN_REGION_SIZE = 50;
-        
+        const MIN_REGION_SIZE = 20;
+
         function floodFill(x, y) {
           const stack = [[x, y]];
           let regionSize = 0;
@@ -740,7 +783,7 @@
           }
           return regionSize;
         }
-        
+
         const cleanedMask = new Uint8Array(mask.length);
         for (let y = 0; y < height; y++) {
           for (let x = 0; x < width; x++) {

--- a/main_old_working - Copy.html
+++ b/main_old_working - Copy.html
@@ -658,11 +658,54 @@
         startTimeInput.max = duration;
       }
 
-      // Remove small blobs from the mask using connected-component analysis
+      // Improve the mask by smoothing edges and removing small blobs
       function cleanMask(mask, width, height) {
+        function dilate(src) {
+          const out = new Uint8Array(src.length);
+          for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+              const idx = y * width + x;
+              if (src[idx]) {
+                for (let dy = -1; dy <= 1; dy++) {
+                  for (let dx = -1; dx <= 1; dx++) {
+                    const nx = x + dx, ny = y + dy;
+                    if (nx >= 0 && nx < width && ny >= 0 && ny < height) {
+                      out[ny * width + nx] = 1;
+                    }
+                  }
+                }
+              }
+            }
+          }
+          return out;
+        }
+
+        function erode(src) {
+          const out = new Uint8Array(src.length);
+          for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+              let keep = true;
+              for (let dy = -1; dy <= 1 && keep; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                  const nx = x + dx, ny = y + dy;
+                  if (nx < 0 || nx >= width || ny < 0 || ny >= height || !src[ny * width + nx]) {
+                    keep = false;
+                    break;
+                  }
+                }
+              }
+              out[y * width + x] = keep ? 1 : 0;
+            }
+          }
+          return out;
+        }
+
+        // Morphological closing to better preserve the person outline
+        mask = erode(dilate(mask));
+
         const visited = new Uint8Array(mask.length);
-        const MIN_REGION_SIZE = 50;
-        
+        const MIN_REGION_SIZE = 20;
+
         function floodFill(x, y) {
           const stack = [[x, y]];
           let regionSize = 0;
@@ -676,7 +719,7 @@
           }
           return regionSize;
         }
-        
+
         const cleanedMask = new Uint8Array(mask.length);
         for (let y = 0; y < height; y++) {
           for (let x = 0; x < width; x++) {


### PR DESCRIPTION
## Summary
- refine mask cleanup in HTML prototype with morphological closing
- adjust small region size threshold for better outline preservation

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6863abfdf2708329b989db85eac92c02